### PR TITLE
Fix video description typo

### DIFF
--- a/intro-to-html/styles/text.css
+++ b/intro-to-html/styles/text.css
@@ -24,7 +24,7 @@ p {
     margin-bottom: 20px;
   }
 
-  .video-discription {
+  .video-description {
     font-size: 14px;
     color: rgb(96, 96, 96);
     margin-top: 0;

--- a/intro-to-html/text.html
+++ b/intro-to-html/text.html
@@ -21,7 +21,7 @@
 
     <p class="video-author">Marques Brownlee &#10003;</p>
 
-    <p class="video-discription">
+    <p class="video-description">
       Talking tech and AI on the heel of Google I/O. Also a daily driver phone
       reveal from Google's CEO. Shoutout to Sundar!
     </p>


### PR DESCRIPTION
## Summary
- fix class name typo from `video-discription` to `video-description`

## Testing
- `grep -R "video-description" -n`


------
https://chatgpt.com/codex/tasks/task_e_6854bf0996ac8332838a37968612ee04